### PR TITLE
Remove an absolute path in thumbnails preview links

### DIFF
--- a/app/helpers/lightbox_helper.rb
+++ b/app/helpers/lightbox_helper.rb
@@ -40,7 +40,7 @@ module LightboxHelper
     link_to image_tag(thumbnail_path(attachment),
                       srcset: "#{thumbnail_path attachment, size: thumbnail_size * 2} 2x",
                       style: "max-width: #{thumbnail_size}px; max-height: #{thumbnail_size}px;"),
-            download_named_attachment_url(attachment, filename: attachment.filename),
+            download_named_attachment_path(attachment, filename: attachment.filename),
             options
   end
 


### PR DESCRIPTION
Sometimes when a user trying to click image preview link the error appears:

![image](https://user-images.githubusercontent.com/49897128/214800382-61962c9c-6a0f-4b29-9ca1-c4498a03cd81.png)

After digging up I've noticed that all thumbnails links have href attribute that references an http protocol:

![ksnip_20230126-121847](https://user-images.githubusercontent.com/49897128/214801293-fd9038f4-9d0e-4b62-9797-70719f5be7d6.png)


In my case all that requests to AttachmentsController#download were redirected to https. From debug console I can see that fancybox also tried to get response from redirect but it seems redmine's headers for authentication was lost and server was returning a 401 and the error on first screenshot.

Relative links allow to avoid this kind errors for SSL/TLS connections.