### PR TITLE
Add support for thumbnail links through attachment ID parsing, while excluding download links.

### DIFF
--- a/assets/javascripts/lightbox.js
+++ b/assets/javascripts/lightbox.js
@@ -156,7 +156,7 @@
       });
 
       // Handle duplicate links (same href as lightbox link)
-      const allLinks = document.querySelectorAll('a[href]');
+      const allLinks = document.querySelectorAll('a[href]:not([data-method="delete"])');
       allLinks.forEach(function(link) {
         const attachmentId = parseAttachmentIdFromUrl(link.href);
         if (!attachmentId) return;

--- a/assets/javascripts/lightbox.js
+++ b/assets/javascripts/lightbox.js
@@ -8,6 +8,11 @@
 
   // Store lightbox instance globally to destroy and recreate after AJAX
   let lightboxInstance = null;
+  
+  function parseAttachmentIdFromUrl(url) {
+    const match = url.match(/\/attachments\/(?:download\/)?(\d+)(?:\/|$)/);
+    return match ? match[1] : null;
+  }
 
   function initializeLightbox() {
     // Collect all lightbox links (images and PDFs) in DOM order for unified slideshow
@@ -153,16 +158,22 @@
       // Handle duplicate links (same href as lightbox link)
       const allLinks = document.querySelectorAll('a[href]');
       allLinks.forEach(function(link) {
-        const href = link.href;
+        const attachmentId = parseAttachmentIdFromUrl(link.href);
+        if (!attachmentId) return;
         // Check if this link is NOT already in allLightboxLinks but has same href
         const isInLightboxLinks = allLightboxLinks.some(function(lbLink) {
           return lbLink === link;
         });
 
         if (!isInLightboxLinks) {
+          // Skip download icons
+          if (link.classList.contains('icon-download')) {
+            return;
+          }
+
           // Find index in our unique list
-          const index = allLightboxLinks.findIndex(function(l) {
-            return l.href === href;
+          const index = allLightboxLinks.findIndex(function (l) {
+            return parseAttachmentIdFromUrl(l.href) === attachmentId;
           });
 
           if (index !== -1) {


### PR DESCRIPTION
This pull request introduces the following improvements:
- Added a function to parse attachment IDs from URLs.
- Updated the lightbox initialization logic to match links based on attachment ID rather than the full URL.
- Modified the behavior to exclude links with the icon-download class, preventing download links from being included in the lightbox.